### PR TITLE
Changes to read single digital input/output plus lab 4 implementation

### DIFF
--- a/examples/Digital_Input_Output.py
+++ b/examples/Digital_Input_Output.py
@@ -3,7 +3,7 @@ sys.path.append('../') # This allows us to access files in src
 
 import src.FANUCethernetipDriver as EIP
 
-drive_path = '172.29.209.124' # Beaker
+drive_path = '172.29.208.124' # Beaker
 
 # Read in a list of inputs
 inputList = EIP.readDigitalInputs(drive_path)
@@ -11,9 +11,11 @@ print("Returned list")
 print(inputList)
 
 # Read in 1 input
-EIP.readDigitalInput(drive_path, 1) # DI[1]
-EIP.readDigitalInput(drive_path, 137) # DI[137]
+# EIP.readDigitalInput(drive_path, 1) # DI[1]
+# EIP.readDigitalInput(drive_path, 137) # DI[137]
 
-EIP.readDigitalOutput(drive_path, 5) # DO[5]
+# EIP.readDigitalOutput(drive_path, 5) # DO[5]
 
-
+erorr = EIP.writeR_Register(drive_path,1,0)
+EIP.writeR_Register(drive_path,2,1)
+print("Error:",erorr)

--- a/examples/Digital_Input_Output.py
+++ b/examples/Digital_Input_Output.py
@@ -1,0 +1,19 @@
+import sys
+sys.path.append('../') # This allows us to access files in src
+
+import src.FANUCethernetipDriver as EIP
+
+drive_path = '172.29.209.124' # Beaker
+
+# Read in a list of inputs
+inputList = EIP.readDigitalInputs(drive_path)
+print("Returned list")
+print(inputList)
+
+# Read in 1 input
+EIP.readDigitalInput(drive_path, 1) # DI[1]
+EIP.readDigitalInput(drive_path, 137) # DI[137]
+
+EIP.readDigitalOutput(drive_path, 5) # DO[5]
+
+

--- a/src/FANUCethernetipDriver.py
+++ b/src/FANUCethernetipDriver.py
@@ -1,8 +1,8 @@
 #############
 #
 # FANUC Ethernet/IP Driver
-# Version 1.0
-# 6/2/2023
+# Version 1.1
+# 10/6/2023
 # Shovic, et.al.
 # Center for Intelligent Industrial Robotics
 # University of Idaho
@@ -11,7 +11,7 @@
 # Requires Ethernet/IP FANUC driver and 30 Series Controller
 # 
 
-DEBUG = True
+DEBUG = False
 
 import sys
 sys.path.append('./pycomm3/pycomm3')
@@ -554,15 +554,58 @@ def readDigitalOutputs(drive_path):
         if (DEBUG == True):
           print("myList=", myList) 
         return myList
+  
+
 
 def readDigitalInput(drive_path, InputNumber):
+  '''
+  Read one digital input value (I.E. Read the value at DI[1])
 
-   raise NotImplementedError("readDigitalInput not implemented yet. If you need this function, open an issue or submit a pull request.")
+  :param str drive-path: IP location of the robot
+  :param int InputNumber: Digital Input (DI) you want to read
+  :return: Value at DI[ InputNumber ]
+  :rtype: int (1 or 0)
+
+  :raises ValueError: if InputNumber <=0
+  '''
+  # Each input register is 8-bits long (I.E. R1 holds DI[1:8])
+  if not InputNumber: # If Input is 0
+    raise ValueError("Cannot select 0-th register, does not exist")
+
+  inputs = readDigitalInputs(drive_path) # Read in all registers
+  register = ((InputNumber-1)//8) # What register block the input is in
+  value = inputs[register] >> ((InputNumber-1)  % 8) # Get the value at the input position requested and whatever is to the right
+  value = value &1 # Truncate to just the position
+  #print("Register Num:",register)
+  #print("Full Register:",inputs[register])
+  print("Value:", value)
+  return value
 
 
 def readDigitalOutput(drive_path, OutputNumber):
+  '''
+  Read one digital output value (I.E. Read the value at DO[1])
 
-   raise NotImplementedError("readDigitalOutput not implemented yet. If you need this function, open an issue or submit a pull request.")
+  :param str drive-path: IP location of the robot
+  :param int OutputNumber: Digital Output (DO) you want to read
+  :return: Value at DO[ OutputNumber ]
+  :rtype: int (1 or 0)
+
+  :raises ValueError: if OutputNumber <=0
+  '''
+  # Each input register is 8-bits long (I.E. R1 holds DO[1:8])
+  if not OutputNumber: # If Input is 0
+    raise ValueError("Cannot select 0-th register, does not exist")
+
+  inputs = readDigitalOutputs(drive_path) # Read in all registers
+  register = ((OutputNumber-1)//8) # What register block the input is in
+  value = inputs[register] >> ((OutputNumber-1)  % 8) # Get the value at the input position requested and whatever is to the right
+  value = value &1 # Truncate to just the position
+  #print("Register Num:",register)
+  #print("Full Register:",inputs[register])
+  print("Value:", value)
+  return value
+   
 
 def writeDigitalInput(drive_path, OutputNumber, Value):
 

--- a/src/FANUCethernetipDriver.py
+++ b/src/FANUCethernetipDriver.py
@@ -608,6 +608,10 @@ def readDigitalOutput(drive_path, OutputNumber):
    
 
 def writeDigitalInput(drive_path, OutputNumber, Value):
+  """
+  Fanuc does not support writes to DI/DO with explicit messaging (what we are doing here).
+  Possible work around in the future?
+  """
   raise NotImplementedError("writeDigialInput: This function will do nothing. WIP")
   register = ((OutputNumber-1)//8) # What register block the output is in
   bit = ((OutputNumber-1) % 8) # What bit in that register needs to be edited

--- a/src/robot_controller.py
+++ b/src/robot_controller.py
@@ -15,6 +15,7 @@
 # @section author_robot_controller Authors(s)
 # - Original Code by John Shovic
 # - Modified by James Lasso on 6/12/2023
+# - Mofified by Kris Olds on 10/6/2023
 #
 
 # Imports
@@ -48,6 +49,7 @@ class robot:
         """! Updates the robots joint position list.
         """
         self.CurJointPosList = FANUCethernetipDriver.returnJointCurrentPosition(self.robot_IP)
+        return self.CurJointPosList
 
     # read PR[1] Joint Coordinates
     def read_joint_position_register(self):
@@ -56,6 +58,7 @@ class robot:
         PR_1_Value = FANUCethernetipDriver.readJointPositionRegister(self.robot_IP, self.PRNumber)
         print("PR[%d]"% self.PRNumber)
         print("list=", PR_1_Value)
+        return PR_1_Value
 
     # write PR[1] offset
     def write_joint_offset(self, joint, value):
@@ -162,6 +165,7 @@ class robot:
         CurPosList = FANUCethernetipDriver.returnCartesianCurrentPostion(self.robot_IP)
 
         print("CURPOS=", CurPosList)
+        return CurPosList
 
     # read PR[1] Cartesian Coordinates
     def read_cartesian_position_register(self):
@@ -174,6 +178,7 @@ class robot:
         PR_1_Value = FANUCethernetipDriver.readCartesianPositionRegister(self.robot_IP, self.PRNumber)
         print("PR[%d]"% self.PRNumber)
         print("list=", PR_1_Value)
+        return PR_1_Value
 
     # DEPRACTED FUNCTION
     # WILL BE REMOVED IN NEXT UPDATE

--- a/src/robot_controller.py
+++ b/src/robot_controller.py
@@ -452,3 +452,25 @@ class robot:
             FANUCethernetipDriver.writeR_Register(self.robot_IP, forward_register, off)
             ## Set sync bit to update
             FANUCethernetipDriver.writeR_Register(self.robot_IP, sync_register, sync_value)
+
+
+    def read_robot_connection_bit(self):
+        """
+        Reads and returns the value at DI[1]
+        """
+        value = FANUCethernetipDriver.readDigitalInput(self.robot_IP,1)
+        return value
+    
+
+    def write_robot_connection_bit(self,status):
+        """
+        Writes a value to R[1]->DO[1]
+        """
+        if status > 1 or status < 0:
+            raise ValueError("Value must be either 1 or 0")
+        DigitalOut = 1
+        sync_register = 2
+        sync_value = 1
+        FANUCethernetipDriver.writeR_Register(self.robot_IP, DigitalOut, status)
+        ## Set sync bit to update
+        FANUCethernetipDriver.writeR_Register(self.robot_IP, sync_register, sync_value)

--- a/src/robot_controller.py
+++ b/src/robot_controller.py
@@ -15,7 +15,7 @@
 # @section author_robot_controller Authors(s)
 # - Original Code by John Shovic
 # - Modified by James Lasso on 6/12/2023
-# - Mofified by Kris Olds on 10/6/2023
+# - Mofified by Kris Olds on 10/8/2023
 #
 
 # Imports

--- a/src/robot_controller.py
+++ b/src/robot_controller.py
@@ -452,12 +452,3 @@ class robot:
             FANUCethernetipDriver.writeR_Register(self.robot_IP, forward_register, off)
             ## Set sync bit to update
             FANUCethernetipDriver.writeR_Register(self.robot_IP, sync_register, sync_value)
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
FANUC_ethernet_driver.py :
    Parse the message from previously created function, so now you can read the value at a specific DI/DO register.
    Write to DI/DO has a pin in it for now. Only issue is sending to robot.
robot_controller.py :  
    Added returns for some 'getter'/'reader' functions in robot_controller.py that did not previously have them (I.E. get_coords) by student request
    Added functions to read and write the robot-connection-bit at DI/DO 1 **(Requires change to ROS2_EIP_BACK)** (DO[1] = R[1])

