### PR TITLE
Delay Gripper by Default

### DIFF
--- a/src/robot_controller.py
+++ b/src/robot_controller.py
@@ -319,6 +319,7 @@ class robot:
     def schunk_gripper(self, command:str, wait:bool=True):
         """! controls schunk gripper.
         @param command      string 'open' or 'close'
+        @param wait         wait until the gripper stops moving
         """
         # !! Registers 20 and 23 need to be toggled for opening and closing !!
 

--- a/src/robot_controller.py
+++ b/src/robot_controller.py
@@ -20,9 +20,9 @@
 
 # Imports
 import math
+import time
 import typing
 import FANUCethernetipDriver
-import time
 
 ## The mode of operation; 
 


### PR DESCRIPTION
- Use onRobot `is_busy` status bit to wait until the gripper stops moving
- Add a half second delay after opening/closing the schunk gripper (this is how TP programs function by default)
- Remove unused `onRobot_gripper_close()`